### PR TITLE
Return false for empty string

### DIFF
--- a/lib/cmd/utils.go
+++ b/lib/cmd/utils.go
@@ -199,6 +199,10 @@ func EnclosedEnvironmentVariableSymbol(s string) string {
 }
 
 func MustBeEnclosed(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
 	runes := []rune(s)
 
 	if runes[0] != '_' && !unicode.IsLetter(runes[0]) {

--- a/lib/cmd/utils_test.go
+++ b/lib/cmd/utils_test.go
@@ -118,9 +118,16 @@ func TestRuntimeInformationSymbol(t *testing.T) {
 func TestMustBeEnclosed(t *testing.T) {
 	var expect bool
 
-	s := "1abc123"
-	expect = true
+	s := ""
+	expect = false
 	result := MustBeEnclosed(s)
+	if result != expect {
+		t.Errorf("must be enclosed = %t, want %t for %q", result, expect, s)
+	}
+
+	s = "1abc123"
+	expect = true
+	result = MustBeEnclosed(s)
 	if result != expect {
 		t.Errorf("must be enclosed = %t, want %t for %q", result, expect, s)
 	}


### PR DESCRIPTION
If there are environment variables which have empty value, csvq panic.

```
csvq interactive shell
Press Ctrl+D or execute "EXIT;" to terminate this shell.

[snip]
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/mithrandie/csvq/lib/cmd.MustBeEnclosed(0xc0001200e0, 0x0, 0xc000086ff0)
	c:/dev/godev/src/github.com/mithrandie/csvq/lib/cmd/utils.go:204 +0x256
github.com/mithrandie/csvq/lib/cmd.EnvironmentVariableSymbol(0xc0001200e0, 0x0, 0x7c4a96, 0x1)
	c:/dev/godev/src/github.com/mithrandie/csvq/lib/cmd/utils.go:191 +0x43
github.com/mithrandie/csvq/lib/query.(*Completer).updateEnvironmentVariables(0xc0000fc000)
	c:/dev/godev/src/github.com/mithrandie/csvq/lib/query/completer_readline.go:268 +0x1bb
github.com/mithrandie/csvq/lib/query.(*Completer).Update(0xc0000fc000)
	c:/dev/godev/src/github.com/mithrandie/csvq/lib/query/completer_readline.go:183 +0x7d
github.com/mithrandie/csvq/lib/query.ReadLineTerminal.UpdateCompleter(...)
	c:/dev/godev/src/github.com/mithrandie/csvq/lib/query/terminal_readline.go:122
github.com/mithrandie/csvq/lib/action.LaunchInteractiveShell(0xc00008fad0, 0x0, 0x0)
	c:/dev/godev/src/github.com/mithrandie/csvq/lib/action/run.go:106 +0x1bd
main.main.func9(0xc0000b6160, 0x0, 0x0)
	c:/dev/godev/src/github.com/mithrandie/csvq/main.go:258 +0x98
github.com/urfave/cli.HandleAction(0x755060, 0xc0000566f0, 0xc0000b6160, 0xc0000b2600, 0x0)
	c:/dev/godev/src/github.com/urfave/cli/app.go:501 +0xcf
github.com/urfave/cli.(*App).Run(0xc0000ce000, 0xc000056170, 0x1, 0x1, 0x0, 0x0)
	c:/dev/godev/src/github.com/urfave/cli/app.go:268 +0x59d
main.main()
	c:/dev/godev/src/github.com/mithrandie/csvq/main.go:276 +0x149a
```