### PR TITLE
Add SQL compatible margin to SUBSTR's second argument.

### DIFF
--- a/lib/query/function.go
+++ b/lib/query/function.go
@@ -937,6 +937,9 @@ func Substr(fn parser.Function, args []value.Primary, _ *cmd.Flags) (value.Prima
 	start = int(i.(*value.Integer).Raw())
 	value.Discard(i)
 
+	if start > 0 {
+		start = start - 1
+	}
 	if start < 0 {
 		start = strlen + start
 	}

--- a/lib/query/function_test.go
+++ b/lib/query/function_test.go
@@ -1615,6 +1615,40 @@ func TestRpad(t *testing.T) {
 
 var substrTests = []functionTest{
 	{
+		Name: "Substr with a positive argument",
+		Function: parser.Function{
+			Name: "substr",
+		},
+		Args: []value.Primary{
+			value.NewString("abcdefghijklmn"),
+			value.NewInteger(5),
+		},
+		Result: value.NewString("efghijklmn"),
+	},
+	{
+		Name: "Substr with a negative argument",
+		Function: parser.Function{
+			Name: "substr",
+		},
+		Args: []value.Primary{
+			value.NewString("abcdefghijklmn"),
+			value.NewInteger(-5),
+		},
+		Result: value.NewString("jklmn"),
+	},
+	{
+		Name: "Substr with two positive argument",
+		Function: parser.Function{
+			Name: "substr",
+		},
+		Args: []value.Primary{
+			value.NewString("abcdefghijklmn"),
+			value.NewInteger(5),
+			value.NewInteger(3),
+		},
+		Result: value.NewString("efg"),
+	},
+	{
 		Name: "Substr",
 		Function: parser.Function{
 			Name: "substr",


### PR DESCRIPTION
I found an issue that csvq's SUBSTR function is not compatible with other SQL products. The second argument of SUBSTR indicates the start position of new string and it means **take from the head** both when it equals to zero and 1. Is this an intentional implementation?

## Repro

```
csvq --no-header "SELECT SUBSTR('abcdefghijklmn', 1)"
```

## Expected

```
+-----------------------------+
| SUBSTR('abcdefghijklmn', 1) |
+-----------------------------+
| abcdefghijklmn              |
+-----------------------------+
```

### Result in BigQuery

<img width="651" alt="スクリーンショット 2019-07-05 14 59 18" src="https://user-images.githubusercontent.com/841131/60701118-867e0680-9f35-11e9-82e2-f4ba95eec3a9.png">

## Actual

```
+-----------------------------+
| SUBSTR('abcdefghijklmn', 1) |
+-----------------------------+
| bcdefghijklmn               |
+-----------------------------+
```

## References
- https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions?hl=en#substr
- https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_substring
