### PR TITLE
Corrected spelling of "concatnation".

### DIFF
--- a/docs/_posts/2006-01-02-string-operators.md
+++ b/docs/_posts/2006-01-02-string-operators.md
@@ -8,7 +8,7 @@ category: reference
 
 | operator | description |
 | :- | :- |
-| \|\| | Concatnation |
+| \|\| | Concatenation |
 
 ## Syntax
 


### PR DESCRIPTION
Corrected spelling of "concatnation" to "concatenation".