### PR TITLE
Update 2006-01-02-string-functions.md

### DIFF
--- a/docs/_posts/2006-01-02-string-functions.md
+++ b/docs/_posts/2006-01-02-string-functions.md
@@ -8,9 +8,9 @@ category: reference
 
 | name | description |
 | :- | :- |
-| [TRIM](#trim) | Return a string with all leading and trailing characters removed |
-| [LTRIM](#ltrim) | Return a string with all leading characters removed |
-| [RTRIM](#rtrim) | Return a string with all trailing characters removed |
+| [TRIM](#trim) | Return a string with all leading and trailing white space characters removed |
+| [LTRIM](#ltrim) | Return a string with all leading white space characters removed |
+| [RTRIM](#rtrim) | Return a string with all trailing white space characters removed |
 | [UPPER](#upper) | Return a string with all characters mapped to their upper case |
 | [LOWER](#lower) | Return a string with all characters mapped to their lower case |
 | [BASE64_ENCODE](#base64_encode) | Return a base64 encoding of a string |


### PR DESCRIPTION
Add "white space" to description of string functions TRIM, LTRIM, and RTRIM.