### PR TITLE
Bypass dispensable redirect in the link in the help

### DIFF
--- a/lib/cli/help.go
+++ b/lib/cli/help.go
@@ -3,7 +3,7 @@ package cli
 var appHHelpTemplate = `Name:
    {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
 
-     https://mithrandie.github.io/csvq
+     https://mithrandie.github.io/csvq/
 
 Usage:
    {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[options]{{end}}{{if .Commands}} [subcommand]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}


### PR DESCRIPTION
Hi. First of all thanks for publishing csvq. It helps me and my team a lot and I appreciate it. 🙂 

This is only a random discovery, but the link in the help says it's 301 moved permanently and redirects to the exact location: the one suffixed with backslash.

Practically it harms nothing but I thought it'd be nice to inform you if you weren't aware. What do you think?