### PR TITLE
Add installation instruction for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Installing using a package manager does not ensure that you always get the lates
 2. ```$ sudo apt update```
 3. ```$ sudo apt install csvq```
 
+#### Arch Linux (unofficial)
+
+Install the [csvq-git](https://aur.archlinux.org/packages/csvq-git) or [csvq-bin](https://aur.archlinux.org/packages/csvq-bin) from the [Arch User Repository](https://wiki.archlinux.org/title/Arch_User_Repository) (e.g. `yay -S csvq-git`)
+
 #### macOS (unofficial)
 
 1. Install homebrew (cf. [The missing package manager for macOS (or Linux) — Homebrew](https://brew.sh))


### PR DESCRIPTION
Hi @mithrandie, thanks for this cool tool.
Some time ago, I made two packages for Arch Linux to make it easier to install.
(`-git` using default branch[=`master`] and `-bin` using precompiled release)

Maybe it is worth mentioning in the README.